### PR TITLE
use fcgi handler instead of cgi handler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV \
 # Install base packages and do the build
 RUN \
     apt-get update \
-&&  apt-get install -y build-essential autoconf git cpanminus unzip rrdtool librrds-perl libnet-ssleay-perl \
+&&  apt-get install -y build-essential autoconf git cpanminus unzip rrdtool librrds-perl libnet-ssleay-perl libapache2-mod-fcgid \
 &&  git clone https://github.com/mad-ady/SmokePing.git \
 &&  cd SmokePing \
 &&  ./bootstrap \

--- a/smokeping.conf
+++ b/smokeping.conf
@@ -1,4 +1,8 @@
+LoadModule fcgid_module modules/mod_fcgid.so
+
 <Directory "/var/www/html/smokeping">
     AllowOverride All
     Options +ExecCGI
+    AddHandler fcgid-script .fcgi
+    DirectoryIndex smokeping.fcgi
 </Directory>


### PR DESCRIPTION
This massively speeds up Smokeping for me.

Idea stolen from from https://github.com/linuxserver/docker-smokeping/commit/b0017937c9900546f3f3683cf773ca4bf37da6f6 and https://www.web-workers.ch/index.php/2017/06/21/how-to-install-smokeping-on-centos-7/