### PR TITLE
redirect from web root to /smokeping

### DIFF
--- a/smokeping.conf
+++ b/smokeping.conf
@@ -1,5 +1,7 @@
 LoadModule fcgid_module modules/mod_fcgid.so
 
+RedirectMatch permanent ^/$ /smokeping/
+
 <Directory "/var/www/html/smokeping">
     AllowOverride All
     Options +ExecCGI


### PR DESCRIPTION
Redirect requests for `http://<host>/` to `http://<host>/smokeping/` to help people find Smokeping's UI